### PR TITLE
Added test case for functions defined with variable declaration

### DIFF
--- a/__tests__/unit/functions.spec.js
+++ b/__tests__/unit/functions.spec.js
@@ -36,41 +36,7 @@ describe("Function Declaration", () => {
 
     expect(output).toBe(expected);
   });
-  test("should export nameless function defined as const ", () => {
-    const code = `
-      const add = (num1, num2)=> {
-        return num1 + num2;
-      }
 
-      function subtrack() {
-        return true;
-      }
-
-      module.exports = add;
-    `;
-
-    const output = generateCode({
-      code: code,
-      testFramework: "jest",
-      filename: "my-module.js",
-      removeWhitespace: true
-    });
-
-    const expected = `
-      const add = require("my-module");
-
-      describe("my-module.js", () => {
-        test("add", () => {
-          const num1 = null;
-          const num2 = null;
-          const result = add(num1, num2);
-        });
-      });`
-      .replace(/ /g, "")
-      .trim();
-
-    expect(output).toBe(expected);
-  });
   test("should export function that does not return", () => {
     const code = `
       function something() { }

--- a/__tests__/unit/functions.spec.js
+++ b/__tests__/unit/functions.spec.js
@@ -36,7 +36,41 @@ describe("Function Declaration", () => {
 
     expect(output).toBe(expected);
   });
+  test("should export nameless function defined as const ", () => {
+    const code = `
+      const add = (num1, num2)=> {
+        return num1 + num2;
+      }
 
+      function subtrack() {
+        return true;
+      }
+
+      module.exports = add;
+    `;
+
+    const output = generateCode({
+      code: code,
+      testFramework: "jest",
+      filename: "my-module.js",
+      removeWhitespace: true
+    });
+
+    const expected = `
+      const add = require("my-module");
+
+      describe("my-module.js", () => {
+        test("add", () => {
+          const num1 = null;
+          const num2 = null;
+          const result = add(num1, num2);
+        });
+      });`
+      .replace(/ /g, "")
+      .trim();
+
+    expect(output).toBe(expected);
+  });
   test("should export function that does not return", () => {
     const code = `
       function something() { }

--- a/__tests__/unit/functions.spec.js
+++ b/__tests__/unit/functions.spec.js
@@ -71,6 +71,68 @@ describe("Function Declaration", () => {
 
     expect(output).toBe(expected);
   });
+  test("should consider direct export functions", () => {
+    const code = `
+      const add = (num1, num2)=> {
+        return num1 + num2;
+      }
+
+      function subtrack() {
+        return true;
+      }
+
+      export default add;
+    `;
+
+    const output = generateCode({
+      code: code,
+      testFramework: "jest",
+      filename: "my-module.js",
+      removeWhitespace: true
+    });
+
+    const expected = `
+      import add from "my-module";
+      describe("my-module.js", () => {
+        test("add", () => {
+          const num1 = null;
+          const num2 = null;
+          const result = add(num1, num2);
+        });
+      });`
+      .replace(/ /g, "")
+      .trim();
+
+    expect(output).toBe(expected);
+  });
+  test("should consider export const functions", () => {
+    const code = `
+      export const add = (num1, num2)=> {
+        return num1 + num2;
+      }
+    `;
+
+    const output = generateCode({
+      code: code,
+      testFramework: "jest",
+      filename: "my-module.js",
+      removeWhitespace: true
+    });
+
+    const expected = `
+      import {add} from "my-module";
+      describe("my-module.js", () => {
+        test("add", () => {
+          const num1 = null;
+          const num2 = null;
+          const result = add(num1, num2);
+        });
+      });`
+      .replace(/ /g, "")
+      .trim();
+
+    expect(output).toBe(expected);
+  });
   test("should export function that does not return", () => {
     const code = `
       function something() { }

--- a/__tests__/unit/functions.spec.js
+++ b/__tests__/unit/functions.spec.js
@@ -71,68 +71,7 @@ describe("Function Declaration", () => {
 
     expect(output).toBe(expected);
   });
-  test("should consider direct export functions", () => {
-    const code = `
-      const add = (num1, num2)=> {
-        return num1 + num2;
-      }
 
-      function subtrack() {
-        return true;
-      }
-
-      export default add;
-    `;
-
-    const output = generateCode({
-      code: code,
-      testFramework: "jest",
-      filename: "my-module.js",
-      removeWhitespace: true
-    });
-
-    const expected = `
-      import add from "my-module";
-      describe("my-module.js", () => {
-        test("add", () => {
-          const num1 = null;
-          const num2 = null;
-          const result = add(num1, num2);
-        });
-      });`
-      .replace(/ /g, "")
-      .trim();
-
-    expect(output).toBe(expected);
-  });
-  test("should consider export const functions", () => {
-    const code = `
-      export const add = (num1, num2)=> {
-        return num1 + num2;
-      }
-    `;
-
-    const output = generateCode({
-      code: code,
-      testFramework: "jest",
-      filename: "my-module.js",
-      removeWhitespace: true
-    });
-
-    const expected = `
-      import {add} from "my-module";
-      describe("my-module.js", () => {
-        test("add", () => {
-          const num1 = null;
-          const num2 = null;
-          const result = add(num1, num2);
-        });
-      });`
-      .replace(/ /g, "")
-      .trim();
-
-    expect(output).toBe(expected);
-  });
   test("should export function that does not return", () => {
     const code = `
       function something() { }
@@ -251,6 +190,107 @@ describe("Function Expression", () => {
           const result = util.add(num1, num2);
         });
       }); `
+      .replace(/ /g, "")
+      .trim();
+
+    expect(output).toBe(expected);
+  });
+});
+
+describe("Arrow Function Expression", () => {
+  test("should consider direct export functions", () => {
+    const code = `
+      const add = (num1, num2)=> {
+        return num1 + num2;
+      }
+
+      function subtrack() {
+        return true;
+      }
+
+      export default add;
+    `;
+
+    const output = generateCode({
+      code: code,
+      testFramework: "jest",
+      filename: "my-module.js",
+      removeWhitespace: true
+    });
+
+    const expected = `
+      import add from "my-module";
+      describe("my-module.js", () => {
+        test("add", () => {
+          const num1 = null;
+          const num2 = null;
+          const result = add(num1, num2);
+        });
+      });`
+      .replace(/ /g, "")
+      .trim();
+
+    expect(output).toBe(expected);
+  });
+  test("should consider export const functions", () => {
+    const code = `
+      export const add = (num1, num2)=> {
+        return num1 + num2;
+      }
+    `;
+
+    const output = generateCode({
+      code: code,
+      testFramework: "jest",
+      filename: "my-module.js",
+      removeWhitespace: true
+    });
+
+    const expected = `
+      import {add} from "my-module";
+      describe("my-module.js", () => {
+        test("add", () => {
+          const num1 = null;
+          const num2 = null;
+          const result = add(num1, num2);
+        });
+      });`
+      .replace(/ /g, "")
+      .trim();
+
+    expect(output).toBe(expected);
+  });
+  test("function parameters (assignment, object descturcture, and RestElemtn)", () => {
+    const code = `
+    export const add = (num1, {num2})=> {
+      return num1 + num2;
+    }
+    export const add2 = (num1, ...args)=> {
+      return num1 + num2;
+    }
+  `;
+
+    const output = generateCode({
+      code: code,
+      testFramework: "jest",
+      filename: "my-module.js",
+      removeWhitespace: true
+    });
+
+    const expected = `
+    import {add, add2} from "my-module";
+    describe("my-module.js", () => {
+      test("add", () => {
+        const num1 = null;
+        const param1 = null;
+        const result = add(num1, param1);
+      });
+      test("add2", () => {
+        const num1 = null;
+        const args = null;
+        const result = add2(num1, args);
+      });
+    });`
       .replace(/ /g, "")
       .trim();
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
       "lcov",
       "text",
       "html"
-    ],
-    "testURL":"http://localhost/"
+    ]
   },
   "dependencies": {
     "@babel/template": "7.0.0-beta.52",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
       "lcov",
       "text",
       "html"
-    ]
+    ],
+    "testURL": "http://localhost/"
   },
   "dependencies": {
     "@babel/template": "7.0.0-beta.52",
@@ -41,7 +42,7 @@
     "babel-traverse": "6.26.0",
     "babel-types": "6.26.0",
     "babylon": "6.18.0",
-    "globby": "8.0.1",
+    "globby": "^9.0.0",
     "lodash.difference": "4.5.0",
     "minimist": "1.2.0",
     "mkdirp": "0.5.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
       "lcov",
       "text",
       "html"
-    ]
+    ],
+    "testURL":"http://localhost/"
   },
   "dependencies": {
     "@babel/template": "7.0.0-beta.52",

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -332,13 +332,14 @@ function getFunctionDetails(ast) {
   let returns = false;
   let callExpressions = [];
 
-  const n =
-    ast.node.type === "VariableDeclaration"
-      ? ast.node.declarations[0].init
-      : ast.node;
   const type = "function";
-  const params = n.params.reduce((acc, value) => {
-    const param = t.isAssignmentPattern(value) ? value.left.name : value.name;
+  let backupParamNameIndex = 0;
+  const params = ast.node.params.reduce((acc, value) => {
+    const param = t.isAssignmentPattern(value)
+      ? value.left.name
+      : t.isObjectPattern(value)
+        ? `param${++backupParamNameIndex}`
+        : value.name;
 
     acc.push(param);
 

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -339,7 +339,9 @@ function getFunctionDetails(ast) {
       ? value.left.name
       : t.isObjectPattern(value)
         ? `param${++backupParamNameIndex}`
-        : value.name;
+        : t.isRestElement(value)
+          ? value.argument.name
+          : value.name;
 
     acc.push(param);
 

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -15,7 +15,6 @@ function generate(ast, filename) {
   let exportDeclarations = [];
 
   testModel.addFilename(filename);
-  // console.log(ast.program.body[0].declarations);
 
   traverse(ast, {
     ImportDeclaration(path) {
@@ -28,25 +27,6 @@ function generate(ast, filename) {
 
     FunctionDeclaration(path) {
       functions = [...functions, path];
-    },
-    // VariableDeclaration(path) {
-    //   const {
-    //     node: { declarations = [] }
-    //   } = path;
-    //   declarations.forEach(d => {
-    //     if (d.init.type === "ArrowFunctionExpression") {
-    //       functions = [...functions, path];
-    //     }
-    //   });
-    // },
-    ArrowFunctionExpression(path) {
-      functionExpressions = [
-        ...functionExpressions,
-        {
-          parentPath: path.parentPath,
-          path: path
-        }
-      ];
     },
 
     FunctionExpression(path) {
@@ -341,12 +321,9 @@ function getFunctionDetails(ast) {
   let variables = [];
   let returns = false;
   let callExpressions = [];
-  let n = ast.node;
-  if (n.type === "VariableDeclaration") {
-    n = n.declarations[0].init;
-  }
+
   const type = "function";
-  const params = n.params.reduce((acc, value) => {
+  const params = ast.node.params.reduce((acc, value) => {
     const param = t.isAssignmentPattern(value) ? value.left.name : value.name;
 
     acc.push(param);
@@ -421,13 +398,7 @@ function getFunctionExpression(opts) {
 
 function getFunctionDeclaration(ast) {
   const callee = [];
-  const n = ast.node;
-  let name = "";
-  if (n.type === "VariableDeclaration") {
-    name = n.declarations[0].id.name;
-  } else {
-    name = ast.node.id.name;
-  }
+  const name = ast.node.id.name;
   const functionDetails = getFunctionDetails(ast);
 
   return Object.assign(functionDetails, { callee, name });

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -489,6 +489,16 @@ function getConstructorFromFunction(opts) {
 
 function getExportDeclarations(declaration) {
   let exportDeclarations = [];
+  if (declaration.type === "default") {
+    exportDeclarations = [
+      ...exportDeclarations,
+      {
+        type: declaration.type,
+        name: declaration.ast.node.declaration.name
+      }
+    ];
+    return exportDeclarations;
+  }
 
   declaration.ast.traverse({
     ExportSpecifier: path => {
@@ -497,6 +507,15 @@ function getExportDeclarations(declaration) {
         {
           type: declaration.type,
           name: path.node.exported.name
+        }
+      ];
+    },
+    ArrowFunctionExpression: path => {
+      exportDeclarations = [
+        ...exportDeclarations,
+        {
+          type: declaration.type,
+          name: path.parent.id.name
         }
       ];
     },

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -489,16 +489,6 @@ function getConstructorFromFunction(opts) {
 
 function getExportDeclarations(declaration) {
   let exportDeclarations = [];
-  if (declaration.type === "default") {
-    exportDeclarations = [
-      ...exportDeclarations,
-      {
-        type: declaration.type,
-        name: declaration.ast.node.declaration.name
-      }
-    ];
-    return exportDeclarations;
-  }
 
   declaration.ast.traverse({
     ExportSpecifier: path => {
@@ -509,6 +499,18 @@ function getExportDeclarations(declaration) {
           name: path.node.exported.name
         }
       ];
+    },
+    Identifier: path => {
+      // This is only for export default add case, the only available node here is the identifier
+      if (path.parent.type === "ExportDefaultDeclaration") {
+        exportDeclarations = [
+          ...exportDeclarations,
+          {
+            type: declaration.type,
+            name: path.node.name
+          }
+        ];
+      }
     },
     ArrowFunctionExpression: path => {
       exportDeclarations = [

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -513,13 +513,15 @@ function getExportDeclarations(declaration) {
       }
     },
     ArrowFunctionExpression: path => {
-      exportDeclarations = [
-        ...exportDeclarations,
-        {
-          type: declaration.type,
-          name: path.parent.id.name
-        }
-      ];
+      if (path.parent.type === "VariableDeclarator") {
+        exportDeclarations = [
+          ...exportDeclarations,
+          {
+            type: declaration.type,
+            name: path.parent.id.name
+          }
+        ];
+      }
     },
 
     ClassDeclaration: path => {

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -15,7 +15,6 @@ function generate(ast, filename) {
   let exportDeclarations = [];
 
   testModel.addFilename(filename);
-  // console.log(ast.program.body[0].declarations);
 
   traverse(ast, {
     ImportDeclaration(path) {
@@ -332,10 +331,11 @@ function getFunctionDetails(ast) {
   let variables = [];
   let returns = false;
   let callExpressions = [];
-  let n = ast.node;
-  if (n.type === "VariableDeclaration") {
-    n = n.declarations[0].init;
-  }
+
+  const n =
+    ast.node.type === "VariableDeclaration"
+      ? ast.node.declarations[0].init
+      : ast.node;
   const type = "function";
   const params = n.params.reduce((acc, value) => {
     const param = t.isAssignmentPattern(value) ? value.left.name : value.name;
@@ -413,12 +413,9 @@ function getFunctionExpression(opts) {
 function getFunctionDeclaration(ast) {
   const callee = [];
   const n = ast.node;
-  let name = "";
-  if (n.type === "VariableDeclaration") {
-    name = n.declarations[0].id.name;
-  } else {
-    name = ast.node.id.name;
-  }
+  const name =
+    n.type === "VariableDeclaration" ? n.declarations[0].id.name : n.id.name;
+
   const functionDetails = getFunctionDetails(ast);
 
   return Object.assign(functionDetails, { callee, name });

--- a/src/model-util.js
+++ b/src/model-util.js
@@ -29,16 +29,7 @@ function generate(ast, filename) {
     FunctionDeclaration(path) {
       functions = [...functions, path];
     },
-    // VariableDeclaration(path) {
-    //   const {
-    //     node: { declarations = [] }
-    //   } = path;
-    //   declarations.forEach(d => {
-    //     if (d.init.type === "ArrowFunctionExpression") {
-    //       functions = [...functions, path];
-    //     }
-    //   });
-    // },
+
     ArrowFunctionExpression(path) {
       functionExpressions = [
         ...functionExpressions,

--- a/src/test-util.js
+++ b/src/test-util.js
@@ -62,8 +62,13 @@ function createMainFileInclude(opts) {
 
       return acc;
     }, []);
+    // the path.relative calculate relative path from the directory to another, so first, convert the file path to directory path
+    const testFolder = path.resolve("__tests__/" + filename, "../");
+    const relativePathForImport = path.relative(testFolder, filename);
 
-    sourceFiles = [t.importDeclaration(specifiers, t.stringLiteral(filename))];
+    sourceFiles = [
+      t.importDeclaration(specifiers, t.stringLiteral(relativePathForImport))
+    ];
   } else {
     sourceFiles = moduleExports.reduce((acc, moduleExport) => {
       if (moduleExport.type === "identifier") {


### PR DESCRIPTION
Added the case where function is defined as 
```
const add = (num1, num2)=>{
}
```
This currently is not considered  and test case is not generated for these functions. 